### PR TITLE
chore(security): fail on Snyk HIGH/CRITICAL container vulnerabilities and upload JSON results

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -243,6 +243,40 @@ jobs:
         with:
           sarif_file: snyk-container.sarif
 
+      - name: Set up Node.js for Snyk CLI
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Run Snyk container test (JSON)
+        id: snyk-json
+        run: |
+          # run test and write JSON output; allow non-zero exit so we can inspect results
+          snyk container test external-dns-technitium-webhook:${{ github.sha }} --json > snyk-container.json || true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Upload Snyk JSON results
+        uses: actions/upload-artifact@v4
+        with:
+          name: snyk-container-json
+          path: snyk-container.json
+
+      - name: Fail on HIGH or CRITICAL Snyk vulnerabilities
+        run: |
+          if [ ! -f snyk-container.json ]; then echo "snyk-container.json not found"; exit 0; fi
+          HIGH_COUNT=$(jq '[.vulnerabilities[]? | select(.severity=="high" or .severity=="critical")] | length' snyk-container.json)
+          echo "Found $HIGH_COUNT high/critical Snyk vulnerabilities"
+          if [ "$HIGH_COUNT" -gt 0 ]; then
+            echo "Failing because high/critical vulnerabilities found by Snyk"
+            exit 1
+          fi
+
       - name: Run Snyk container monitor (track over time)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: snyk/actions/docker@master


### PR DESCRIPTION
This PR adds a Snyk container JSON scan to the Security workflow and fails the job if any HIGH or CRITICAL vulnerabilities are found.\n\nChanges:\n- Install Snyk CLI and run  with JSON output\n- Upload  artifact\n- Parse JSON and fail the job when HIGH/CRITICAL vulnerabilities exist\n\nNotes:\n- Ensure  is set in repository secrets.