### PR TITLE
release: v1.0.8

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -205,7 +205,6 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     name: Snyk Security Analysis
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,8 @@ jobs:
           category: "/language:${{matrix.language}}"
 
   container-scan:
+    # GitHub does not provide repository secrets to Dependabot-triggered workflows.
+    if: github.actor != 'dependabot[bot]'
     name: Container Scan (Snyk)
     runs-on: ubuntu-latest
     permissions:
@@ -199,6 +201,8 @@ jobs:
           retention-days: 90
 
   snyk-security:
+    # GitHub does not provide repository secrets to Dependabot-triggered workflows.
+    if: github.actor != 'dependabot[bot]'
     name: Snyk Security Analysis
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.8] - 2026-07-20
+
+### Fixed
+
+- Skip token-dependent Snyk jobs on Dependabot pull requests, where GitHub does not provide repository secrets.
+
+### Improved
+
+- Keep CodeQL, Semgrep, Grype, and SBOM checks enabled for Dependabot pull requests.
+
 ## [v1.0.7] - 2026-07-19
 
 ### Fixed & Improved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "external-dns-technitium-webhook"
-version = "1.0.7"
+version = "1.0.8"
 description = "ExternalDNS webhook provider for Technitium DNS"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"


### PR DESCRIPTION
## Fixed
- Skip token-dependent Snyk jobs for Dependabot pull requests, where GitHub does not provide repository secrets.

## Improved
- Keep CodeQL, Semgrep, Grype, and SBOM checks enabled for Dependabot pull requests.