### PR TITLE
release: 1.0.13 — SonarCloud code-smell remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.13] - 2026-07-25
+
+### Fixed
+
+- Remove redundant `exc_info=True` from `logger.error()` calls inside exception handlers; use `logger.exception()` which always includes the traceback (SonarCloud code-smell remediation).
+
 ## [v1.0.12] - 2026-07-25
 
 ### Security

--- a/external_dns_technitium_webhook/handlers.py
+++ b/external_dns_technitium_webhook/handlers.py
@@ -283,7 +283,7 @@ async def _handle_get_records_error(state: AppState, exc: TechnitiumError) -> Ge
     """
     if not _is_connection_error(exc):
         # Not a connection error, return error response
-        logger.error("API error during get_records: %s", exc, exc_info=True)
+        logger.exception("API error during get_records: %s", exc)
         sanitized = sanitize_error_message(exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -400,7 +400,7 @@ async def _handle_apply_record_error(
     """
     if not _is_connection_error(exc):
         # Not a connection error, return error response
-        logger.error("API error during record application: %s", exc, exc_info=True)
+        logger.exception("API error during record application: %s", exc)
         sanitized = sanitize_error_message(exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "external-dns-technitium-webhook"
-version = "1.0.12"
+version = "1.0.13"
 description = "ExternalDNS webhook provider for Technitium DNS"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"


### PR DESCRIPTION
## Release 1.0.13

### Changed
- Remove redundant `exc_info=True` from two `logger.error()` calls in `handlers.py`; use `logger.exception()` which always includes the traceback (SonarCloud code-smell remediation).

### Verification (local, delegated)
- `ruff format --check`: 2 files already formatted ✓
- `ruff check`: All checks passed ✓
- `pytest tests/unit/test_handlers.py -q`: 77 passed ✓

### Release artifacts
- `pyproject.toml` version: 1.0.12 → 1.0.13
- `CHANGELOG.md`: [v1.0.13] entry added
