### PR TITLE
release: v1.0.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
           args: --sarif-file-output=snyk-release-scan.sarif --json-file-output=snyk-release-report.json
 
       - name: Upload Snyk results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: 'snyk-release-scan.sarif'
           category: 'release-snyk'

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -115,7 +115,7 @@ jobs:
           args: --sarif-file-output=snyk-results.sarif --json-file-output=snyk-report.json
 
       - name: Upload Snyk SARIF results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: 'snyk-results.sarif'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -80,7 +80,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"
 
@@ -109,7 +109,7 @@ jobs:
           args: --sarif-file-output=snyk-container.sarif --json-file-output=snyk-container.json --severity-threshold=low
 
       - name: Upload Snyk container SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: snyk-container.sarif
@@ -266,7 +266,7 @@ jobs:
           args: --severity-threshold=medium --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk results to GitHub Security
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: snyk-code.sarif
@@ -293,7 +293,7 @@ jobs:
           args: --severity-threshold=high --sarif-file-output=snyk-container.sarif
 
       - name: Upload Snyk container SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: snyk-container.sarif
@@ -392,7 +392,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.16] - 2026-08-09
+
+### Fixed
+
+- Preserve the token issued to a temporary primary-health probe before its authenticated zone query, preventing false `invalid-token` failures during failback detection.
+- Prevent a token renewal completing after failover or failback from installing a token issued by the previous endpoint on the newly active client.
+
+### Changed
+
+- Update FastAPI to 0.141.1, Uvicorn to 0.52.0, Ruff to 0.16.1, and all CodeQL actions to 4.37.3.
+
 ## [v1.0.15] - 2026-07-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update FastAPI to 0.141.1, Uvicorn to 0.52.0, Ruff to 0.16.1, and all CodeQL actions to 4.37.3.
+- Update FastAPI to 0.141.1, Uvicorn to 0.52.1, Ruff to 0.16.1, and all CodeQL actions to 4.37.3.
 
 ## [v1.0.15] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update FastAPI to 0.141.1, Uvicorn to 0.52.1, Ruff to 0.16.1, and all CodeQL actions to 4.37.3.
+- Update FastAPI to 0.141.1, HTTPX2 to 2.10.0, Pydantic Settings to 2.15.0, Uvicorn to 0.52.1, Ruff to 0.16.2, and all CodeQL actions to 4.37.3.
 
 ## [v1.0.15] - 2026-07-28
 

--- a/external_dns_technitium_webhook/main.py
+++ b/external_dns_technitium_webhook/main.py
@@ -528,12 +528,19 @@ async def auto_renew_technitium_token(state: AppState) -> None:
         logger.debug("Token renewal cycle started (sleep interval: %.1f sec)", sleep_for)
 
         try:
-            login_response = await state.client.login(
+            # Keep the client used for login.  Failback/failover can replace
+            # state.client while this request is in flight; a token issued by
+            # the previous server must never be installed on the new client.
+            client = state.client
+            login_response = await client.login(
                 username=state.config.technitium_username,
                 password=state.config.technitium_password,
             )
-            state.client.token = login_response.token
-            logger.debug("Successfully renewed Technitium DNS server access token")
+            if state.client is client:
+                client.token = login_response.token
+                logger.debug("Successfully renewed Technitium DNS server access token")
+            else:
+                logger.debug("Discarded token renewed for a no-longer-active Technitium endpoint")
             sleep_for = DURATION_TOKEN_SUCCESS
         except (
             TechnitiumError,
@@ -674,6 +681,7 @@ async def _probe_primary_endpoint(state: AppState, primary_endpoint: str) -> Pri
             username=state.config.technitium_username,
             password=state.config.technitium_password,
         )
+        temp_client.token = login_response.token
         zone_options = await temp_client.get_zone_options(
             state.config.zone, include_catalog_names=True
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
     # is present in their metadata.
     "fastapi==0.141.1",
     "uvicorn[standard]==0.52.1",
-    "httpx2==2.9.1",
+    "httpx2==2.10.0",
     "pydantic==2.13.4",
-    "pydantic-settings==2.14.2",
+    "pydantic-settings==2.15.0",
     "prometheus-client==0.26.0",
 ]
 
@@ -45,9 +45,9 @@ dev = [
     "coverage>=7.13.5",
     "pytest-asyncio==1.4.0",
     "pytest-mock==3.15.1",
-    "httpx2==2.9.1",
+    "httpx2==2.10.0",
     "kubernetes==36.0.3",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "mypy==2.3.0",
     "pyright==1.1.411",
     "semgrep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # are known to be compatible with CPython 3.14 when no upper bound
     # is present in their metadata.
     "fastapi==0.141.1",
-    "uvicorn[standard]==0.52.0",
+    "uvicorn[standard]==0.52.1",
     "httpx2==2.9.1",
     "pydantic==2.13.4",
     "pydantic-settings==2.14.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "external-dns-technitium-webhook"
-version = "1.0.15"
+version = "1.0.16"
 description = "ExternalDNS webhook provider for Technitium DNS"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"
@@ -29,8 +29,8 @@ dependencies = [
     # Bumped to releases that declare support for modern Python (>=3.8) and
     # are known to be compatible with CPython 3.14 when no upper bound
     # is present in their metadata.
-    "fastapi==0.140.13",
-    "uvicorn[standard]==0.51.0",
+    "fastapi==0.141.1",
+    "uvicorn[standard]==0.52.0",
     "httpx2==2.9.1",
     "pydantic==2.13.4",
     "pydantic-settings==2.14.2",
@@ -47,7 +47,7 @@ dev = [
     "pytest-mock==3.15.1",
     "httpx2==2.9.1",
     "kubernetes==36.0.3",
-    "ruff==0.16.0",
+    "ruff==0.16.1",
     "mypy==2.3.0",
     "pyright==1.1.411",
     "semgrep",

--- a/tests/unit/test_ci_workflow_safety.py
+++ b/tests/unit/test_ci_workflow_safety.py
@@ -25,7 +25,7 @@ def test_security_skips_push_jobs_only_when_the_branch_has_an_open_pr() -> None:
 
 def test_security_workflow_uses_one_codeql_action_revision() -> None:
     workflow = SECURITY_WORKFLOW.read_text(encoding="utf-8")
-    codeql_action_sha = "7211b7c8077ea37d8641b6271f6a365a22a5fbfa"
+    codeql_action_sha = "e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81"
     codeql_lines = [line for line in workflow.splitlines() if "uses: github/codeql-action/" in line]
     assert codeql_lines
     assert all(f"@{codeql_action_sha}" in line for line in codeql_lines)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1018,6 +1018,38 @@ async def test_auto_renew_token_success_sets_token(mocker: MockerFixture) -> Non
 
 
 @pytest.mark.asyncio
+async def test_auto_renew_token_does_not_overwrite_token_after_endpoint_rotation(
+    mocker: MockerFixture,
+) -> None:
+    """A renewal started on an old endpoint must not update the new endpoint's token."""
+
+    config = _build_config()
+    old_client = SimpleNamespace(token="old-token")
+    active_client = SimpleNamespace(token="active-token")
+    state = SimpleNamespace(config=config, client=old_client)
+
+    async def login_on_old_endpoint(*args: object, **kwargs: object) -> SimpleNamespace:
+        state.client = active_client
+        return SimpleNamespace(token="old-endpoint-token")
+
+    old_client.login = AsyncMock(side_effect=login_on_old_endpoint)
+    sleep_mock = mocker.patch(
+        "external_dns_technitium_webhook.main.asyncio.sleep",
+        new_callable=AsyncMock,
+        side_effect=[None, asyncio.CancelledError()],
+    )
+
+    from contextlib import suppress
+
+    with suppress(asyncio.CancelledError):
+        await auto_renew_technitium_token(cast(AppState, state))
+
+    assert old_client.token == "old-token"
+    assert active_client.token == "active-token"
+    assert sleep_mock.await_args_list[0].args[0] == 20 * 60
+
+
+@pytest.mark.asyncio
 async def test_auto_renew_token_failure_uses_failure_interval(mocker: MockerFixture) -> None:
     """auto_renew_technitium_token should retry quickly after a failure."""
 
@@ -1320,6 +1352,7 @@ async def test_auto_attempt_failback_recovers_to_writable_primary(
         username=config.technitium_username,
         password=config.technitium_password,
     )
+    assert temp_client.token == "renewed-primary-token"
     temp_client.get_zone_options.assert_awaited_once_with(config.zone, include_catalog_names=True)
     temp_client.close.assert_awaited_once_with()
     state.set_active_endpoint.assert_awaited_once_with("https://primary:5380")


### PR DESCRIPTION
## Summary

- Fix Technitium token handling during primary failback probes and concurrent endpoint rotation.
- Update FastAPI, Uvicorn, and Ruff from the approved Dependabot updates.
- Atomically update all CodeQL actions to v4.37.3 so init, analyze, and SARIF upload use one pinned revision.
- Bump the package to v1.0.16 and document the release.

## Root cause

The primary health probe logged in but did not retain its token before querying zone options, causing false `invalid-token` failures. A separate renewal race could also assign a token from a previous endpoint after failover or failback.

## Validation

- `pytest -q tests/unit` (426 passed)
- Ruff check and format check
- mypy and pyright
- `make security` (Semgrep: 0 findings)

## Release flow

This PR follows the repository's release flow: it promotes `develop` to `main`. Merging it triggers the version-driven release automation.
