### PR TITLE
ci: update CodeQL actions to 4.37.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
           args: --sarif-file-output=snyk-release-scan.sarif --json-file-output=snyk-release-report.json
 
       - name: Upload Snyk results
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: 'snyk-release-scan.sarif'
           category: 'release-snyk'

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -115,7 +115,7 @@ jobs:
           args: --sarif-file-output=snyk-results.sarif --json-file-output=snyk-report.json
 
       - name: Upload Snyk SARIF results
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: 'snyk-results.sarif'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -80,7 +80,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: "/language:${{matrix.language}}"
 
@@ -109,7 +109,7 @@ jobs:
           args: --sarif-file-output=snyk-container.sarif --json-file-output=snyk-container.json --severity-threshold=low
 
       - name: Upload Snyk container SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: snyk-container.sarif
@@ -266,7 +266,7 @@ jobs:
           args: --severity-threshold=medium --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk results to GitHub Security
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: snyk-code.sarif
@@ -293,7 +293,7 @@ jobs:
           args: --severity-threshold=high --sarif-file-output=snyk-container.sarif
 
       - name: Upload Snyk container SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: snyk-container.sarif
@@ -392,7 +392,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype results
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}

--- a/tests/unit/test_ci_workflow_safety.py
+++ b/tests/unit/test_ci_workflow_safety.py
@@ -25,7 +25,7 @@ def test_security_skips_push_jobs_only_when_the_branch_has_an_open_pr() -> None:
 
 def test_security_workflow_uses_one_codeql_action_revision() -> None:
     workflow = SECURITY_WORKFLOW.read_text(encoding="utf-8")
-    codeql_action_sha = "e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81"
+    codeql_action_sha = "d1ba80a13dd99fba24a470575428917156a28b43"
     codeql_lines = [line for line in workflow.splitlines() if "uses: github/codeql-action/" in line]
     assert codeql_lines
     assert all(f"@{codeql_action_sha}" in line for line in codeql_lines)


### PR DESCRIPTION
## Summary

- Update every CodeQL action use to the immutable v4.37.5 revision.
- Keep init, analyze, and SARIF upload on one revision, including the workflow safety test.

## Recovery

This replaces the newer CodeQL updates from Dependabot PRs #222, #225, and #226 after their source branches were closed accidentally.

## Validation

- `pytest -q tests/unit` (426 passed)
- Ruff check and format check
